### PR TITLE
Fix AuthUI DB initialization

### DIFF
--- a/Assets/Plugins/Mono.Data.Sqlite.dll.meta
+++ b/Assets/Plugins/Mono.Data.Sqlite.dll.meta
@@ -1,2 +1,19 @@
 fileFormatVersion: 2
 guid: 3e054465c0be46141bc0a03f1a2770c9
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  platformData:
+  - first:
+      Any: Any
+    second:
+      enabled: 1
+      settings: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Saves/DatabaseManager.cs
+++ b/Assets/Scripts/Saves/DatabaseManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.IO;
 using Mono.Data.Sqlite;
 using UnityEngine;
 
@@ -17,7 +18,12 @@ public class DatabaseManager : MonoBehaviour
         {
             Instance = this;
             DontDestroyOnLoad(gameObject);
-            _dbPath = "URI=file:" + Application.persistentDataPath + "/game.db";
+            var file = Path.Combine(Application.persistentDataPath, "game.db");
+            if (!File.Exists(file))
+            {
+                File.Create(file).Dispose();
+            }
+            _dbPath = "URI=file:" + file;
             Init();
         }
         else

--- a/Assets/Scripts/UI/AuthUI.cs.meta
+++ b/Assets/Scripts/UI/AuthUI.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 204e3e208de2cc049a0285d777e4aa78
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- ensure `game.db` is created on start if missing
- restore proper meta file for `AuthUI.cs`
- restore plugin importer meta for `Mono.Data.Sqlite.dll`

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_6849aef5fab883278beed42f01014494