### PR TITLE
Fix level selection after adding new login scene

### DIFF
--- a/Assets/Scripts/SceneSwitcher.cs
+++ b/Assets/Scripts/SceneSwitcher.cs
@@ -15,7 +15,15 @@ public class SceneSwitcher : MonoBehaviour
     }
     public void Open(int level)
     {
-        SceneManager.LoadScene(level);
+        string sceneName = $"Level {level}";
+        if (Application.CanStreamedLevelBeLoaded(sceneName))
+        {
+            SceneManager.LoadScene(sceneName);
+        }
+        else
+        {
+            SceneManager.LoadScene(level);
+        }
     }
     public void SwitchToNext()
     {

--- a/Assets/Scripts/UI/ChooseLevelButton.cs
+++ b/Assets/Scripts/UI/ChooseLevelButton.cs
@@ -1,6 +1,7 @@
 using TMPro;
 using UnityEngine.UI;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class ChooseLevelButton : MonoBehaviour
 {
@@ -11,11 +12,14 @@ public class ChooseLevelButton : MonoBehaviour
         _btnText = GetComponentInChildren<TextMeshProUGUI>();
         _btnText.text = levelId.ToString();
         var btn = GetComponent<Button>();
-        if (levelId > lastLevelIndex)
+
+        int buildIndex = SceneUtility.GetBuildIndexByScenePath($"Assets/Scenes/Level {levelId}.unity");
+        if (buildIndex == -1 || buildIndex > lastLevelIndex)
         {
             btn.enabled = false;
             GetComponent<Image>().sprite = _notOpenLayout;
         }
+
         btn.onClick.AddListener(delegate
         {
             switcher.Open(levelId);


### PR DESCRIPTION
## Summary
- update ChooseLevelButton to check build index and open levels by name
- make SceneSwitcher attempt to load scenes by name first

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684abe68f0cc83279cfd9dbcbefb27c2